### PR TITLE
Add swagger API documents

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,9 @@ gem 'lefthook', '~> 0.7.7'
 gem 'pundit', '~> 2.2'
 gem 'rack-cors'
 
+# API documents
+gem 'rswag'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,8 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
     bcrypt (3.1.18)
     bootsnap (1.12.0)
@@ -87,6 +89,8 @@ GEM
     io-console (0.5.11)
     irb (1.4.1)
       reline (>= 0.3.0)
+    json-schema (4.3.1)
+      addressable (>= 2.8)
     jwt (2.4.1)
     lefthook (0.7.7)
     loofah (2.18.0)
@@ -127,6 +131,7 @@ GEM
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    public_suffix (6.0.1)
     puma (5.6.4)
       nio4r (~> 2.0)
     pundit (2.2.0)
@@ -186,6 +191,21 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.11.0)
+    rswag (2.13.0)
+      rswag-api (= 2.13.0)
+      rswag-specs (= 2.13.0)
+      rswag-ui (= 2.13.0)
+    rswag-api (2.13.0)
+      activesupport (>= 3.1, < 7.2)
+      railties (>= 3.1, < 7.2)
+    rswag-specs (2.13.0)
+      activesupport (>= 3.1, < 7.2)
+      json-schema (>= 2.2, < 5.0)
+      railties (>= 3.1, < 7.2)
+      rspec-core (>= 2.14)
+    rswag-ui (2.13.0)
+      actionpack (>= 3.1, < 7.2)
+      railties (>= 3.1, < 7.2)
     rubocop (1.31.0)
       parallel (~> 1.10)
       parser (>= 3.1.0.0)
@@ -212,6 +232,7 @@ GEM
 PLATFORMS
   arm64-darwin-23
   x86_64-darwin-21
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -227,6 +248,7 @@ DEPENDENCIES
   rack-cors
   rails (~> 7.0.2, >= 7.0.2.2)
   rspec-rails
+  rswag
   rubocop (~> 1.26)
   tzinfo-data
 

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,0 +1,14 @@
+Rswag::Api.configure do |c|
+
+  # Specify a root folder where Swagger JSON files are located
+  # This is used by the Swagger middleware to serve requests for API descriptions
+  # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
+  # that it's configured to generate files in the same folder
+  c.openapi_root = Rails.root.to_s + '/swagger'
+
+  # Inject a lambda function to alter the returned Swagger prior to serialization
+  # The function will have access to the rack env for the current request
+  # For example, you could leverage this to dynamically assign the "host" property
+  #
+  #c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -1,0 +1,16 @@
+Rswag::Ui.configure do |c|
+
+  # List the Swagger endpoints that you want to be documented through the
+  # swagger-ui. The first parameter is the path (absolute or relative to the UI
+  # host) to the corresponding endpoint and the second is a title that will be
+  # displayed in the document selector.
+  # NOTE: If you're using rspec-api to expose Swagger files
+  # (under openapi_root) as JSON or YAML endpoints, then the list below should
+  # correspond to the relative paths for those endpoints.
+
+  c.swagger_endpoint '/api-docs/v1/swagger.yaml', 'API V1 Docs'
+
+  # Add Basic Auth in case your API is private
+  # c.basic_auth_enabled = true
+  # c.basic_auth_credentials 'username', 'password'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  mount Rswag::Ui::Engine => '/api-docs'
+  mount Rswag::Api::Engine => '/api-docs'
   post '/auth/login', to: 'authentication#login'
   namespace :api do
     namespace :v1 do

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.configure do |config|
+  # Specify a root folder where Swagger JSON files are generated
+  # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
+  # to ensure that it's configured to serve Swagger from the same folder
+  config.openapi_root = Rails.root.join('swagger').to_s
+
+  # Define one or more Swagger documents and provide global metadata for each one
+  # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
+  # be generated at the provided relative path under openapi_root
+  # By default, the operations defined in spec files are added to the first
+  # document below. You can override this behavior by adding a openapi_spec tag to the
+  # the root example_group in your specs, e.g. describe '...', openapi_spec: 'v2/swagger.json'
+  config.openapi_specs = {
+    'v1/swagger.yaml' => {
+      openapi: '3.0.1',
+      info: {
+        title: 'API V1',
+        version: 'v1'
+      },
+      paths: {},
+      servers: [
+        {
+          url: 'https://{defaultHost}',
+          variables: {
+            defaultHost: {
+              default: 'www.example.com'
+            }
+          }
+        }
+      ]
+    }
+  }
+
+  # Specify the format of the output Swagger file when running 'rswag:specs:swaggerize'.
+  # The openapi_specs configuration option has the filename including format in
+  # the key, this may want to be changed to avoid putting yaml in json files.
+  # Defaults to json. Accepts ':json' and ':yaml'.
+  config.openapi_format = :yaml
+end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1,0 +1,118 @@
+openapi: 3.0.1
+info:
+  version: 1.0.0
+  title: Internal API
+  description: >
+    API documentation for the QA team.
+servers:
+  - url: http://localhost:3000
+    description: localhost for connection.
+  - url: https://payrollvn-753d9468206b.herokuapp.com
+    description: Production for connection via internal network.
+    variables:
+      basePath:
+        default: https://payrollvn-753d9468206b.herokuapp.com
+components:
+  securitySchemes:
+    Bearer:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: >
+        Enter the token with the Bearer prefix, e.g., "Bearer abcde12345".
+paths:
+  /auth/login:
+    post:
+      summary: API to get token authorization
+      tags:
+        - api
+      description: API to login
+      parameters:
+        - name: username
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: password
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+                required:
+                  - token
+              examples:
+                example-1:
+                  value: { token: "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoyLCJleHAiOjE3MjI1MDg2ODh9.YW2I0jh9NWChXOTN9yNn8jxlitn6UqyQnobm7prK7cA" }
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              examples:
+                example-1:
+                  value: { "errors": "unauthorized" }
+  /api/v1/users:
+    get:
+      security:
+        - Bearer: []
+      summary: API to get users' information
+      tags:
+        - api
+      description: API to get users
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  username:
+                    type: string
+                  password_digest:
+                    type: string
+                  created_at:
+                    type: string
+                    format: date-time
+                  updated_at:
+                    type: string
+                    format: date-time
+                  admin:
+                    type: boolean
+                required:
+                  - id
+                  - username
+                  - password_digest
+                  - created_at
+                  - updated_at
+                  - admin
+              examples:
+                example-1:
+                  value: [
+                    {
+                      "id": 1,
+                      "username": "Joshua 1",
+                      "password_digest": "$2a$12$aAvO7mcxXMLXvQmZjjXdp.7qeceXT/aA7QjlthCnXAOXc3mYmjnyO",
+                      "created_at": "2024-07-30T08:23:21.810Z",
+                      "updated_at": "2024-07-30T08:23:21.810Z",
+                      "admin": false
+                    }
+                  ]
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              examples:
+                example-1:
+                  value: { "errors": "Signature verification failed" }


### PR DESCRIPTION
Add API document
- Go to link `http://localhost:3000/api-docs/index.html`

![Screenshot 2024-07-31 at 09 55 04](https://github.com/user-attachments/assets/01639a94-daeb-478f-b4db-a52f458f0a7a)
